### PR TITLE
Exchanged P1 and P2 of the SELECT command

### DIFF
--- a/doc/Protocol.txt
+++ b/doc/Protocol.txt
@@ -47,8 +47,8 @@ authentication is configured.
 |=========
 |CLA |0x00
 |INS |0xa4
-|P1  |0x00
-|P2  |0x04
+|P1  |0x04
+|P2  |0x00
 |Lc  |Length of AID
 |Data|AID
 |=========


### PR DESCRIPTION
According to ETSI TS 102 221, the SELECT application command's P1 needs to be 0x04 and P2 needs to be 0x00 to select the first applet with the given AID. The Android application also uses "00 A4 04 00 xx AID" to select the applet, so this seems to be a small typo in the protocol documentation.
