### PR TITLE
Fix test failing because of typo in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ sourceSets {
 	    srcDir 'test/test'
 	}
 	resources {
-	    srcDir ' test/resources'
+	    srcDir 'test/resources'
 	}
 
 	/* Gradle prepends automatically all compile dependencies to the testCompile and testRuntime


### PR DESCRIPTION
On my system the test "TestHugeHotp" was failing because of a tailing space in the gradle test resource configuration. This commit fixes it.
