### PR TITLE
Use transactions when changing non-volatile state

### DIFF
--- a/applet/src/pkgYkneoOath/YkneoOath.java
+++ b/applet/src/pkgYkneoOath/YkneoOath.java
@@ -138,14 +138,18 @@ public class YkneoOath extends Applet {
 		switch (ins) {
 		case PUT_INS: // put
 			if(p1p2 == 0x0000) {
+				javacard.framework.JCSystem.beginTransaction();
 				handlePut(buf);
+				javacard.framework.JCSystem.commitTransaction();
 			} else {
 				ISOException.throwIt(ISO7816.SW_WRONG_P1P2);
 			}
 			break;
 		case DELETE_INS: // delete
 			if(p1p2 == 0x0000) {
+				javacard.framework.JCSystem.beginTransaction();
 				handleDelete(buf);
+				javacard.framework.JCSystem.commitTransaction();
 			} else {
 				ISOException.throwIt(ISO7816.SW_WRONG_P1P2);
 			}
@@ -159,7 +163,9 @@ public class YkneoOath extends Applet {
 			break;
 		case RESET_INS: // reset
 			if(p1p2 == (short)0xdead) {
+				javacard.framework.JCSystem.beginTransaction();
 				handleReset();
+				javacard.framework.JCSystem.commitTransaction();
 			} else {
 				ISOException.throwIt(ISO7816.SW_WRONG_P1P2);
 			}
@@ -321,7 +327,7 @@ public class YkneoOath extends Applet {
 
 		respOffs += setLength(output, respOffs, (short) (len + 1));
 		output[respOffs++] = object.getDigits();
-		Util.arrayCopy(tempBuf, _0, output, respOffs, len);
+		Util.arrayCopyNonAtomic(tempBuf, _0, output, respOffs, len);
 
 		return (short) (len + getLengthBytes(len) + 2);
 	}
@@ -516,7 +522,7 @@ public class YkneoOath extends Applet {
 		if(len < maxLen) {
 			toSend = len;
 		}
-		Util.arrayCopy(sendBuffer, sentData, buf, _0, toSend);
+		Util.arrayCopyNonAtomic(sendBuffer, sentData, buf, _0, toSend);
 		if(len > maxLen) {
 			remainingData = (short) (len - maxLen);
 			sentData += maxLen;


### PR DESCRIPTION
While the JC runtime will guarantee that almost all operations will be performed atomically, this guarantee is only made for individual operations. For example, if a tear occurs while the linked list is being updated, then the list state may become inconsistent and objects may be lost.

This change makes sure that we wrap all high-level commands that change non-volatile state in a transaction. This ensures that tearing won't leave the applet in a bad state.

This change also converts two instances of `arrayCopy` into their non-atomic counterpart, since there is no benefit to them being atomic.