### PR TITLE
Fix getting and setting of the length field

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 jdk:
   - openjdk8
 install:
-  - sudo apt-get install junit4
+  - sudo apt-get install junit4 ant-optional
   - curl -L https://github.com/licel/jcardsim/raw/jc2.2.2/jcardsim-2.2.2-all.jar -o test/lib/jcardsim-2.2.2-all.jar
 script:
   - ant -Dtest.build.mock=1 test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - openjdk7
+  - openjdk8
 install:
   - sudo apt-get install junit4
   - curl -L https://github.com/licel/jcardsim/raw/jc2.2.2/jcardsim-2.2.2-all.jar -o test/lib/jcardsim-2.2.2-all.jar


### PR DESCRIPTION
Here is some code massaging this code which when run against the old code fails pretty fast:

```
import java.util.Arrays;

class Flott {
    // taken from javacard.framework.Util
    public static final short getShort(byte bArray[], short bOff)
        throws ArrayIndexOutOfBoundsException, NullPointerException {
        return (short) (((short) bArray[bOff] << 8) + ((short) bArray[bOff + 1] & 0xff));
    }
    // taken from javacard.framework.Util
    public static final short setShort(byte bArray[], int bOff, int sValue)
        throws ArrayIndexOutOfBoundsException, NullPointerException {
        bArray[bOff] = (byte) (sValue >> 8);
        bArray[bOff + 1] = (byte) sValue;
        return (short) (bOff + 2);
    }

    private static short getLength(byte[] buf, short offs) {
        short length = 0;
        int len = buf[offs] & 0xff;
        if ((len & 0x82) == 0x82) {
            length = getShort(buf, (short) (offs + 1));
        }
        else if ((len & 0x81) == 0x81) {
            length = (short)(buf[offs + 1] & 0xff);
        }
        else if (len <= 0x7f) {
            length = buf[offs];
        }
        else {
            throw new IllegalStateException("ISOException.throwIt(ISO7816.SW_DATA_INVALID);");
        }
        return length;
    }

    private static short setLength(byte[] buf, short offs, int len) {
        if(len < 0x0080) {
            buf[offs] = (byte) len;
            return 1;
        } else if(len < 0x00ff) {
            buf[offs++] = (byte)0x81;
            buf[offs] = (byte) len;
            return 2;
        } else {
            buf[offs++] = (byte)0x82;
            setShort(buf, (short)offs, len);
            return 3;
        }
    }

    public static void main(String[] args)
    {
        for(int i = 0; i < 65535; ++i) {
            byte[] buf = new byte[3];
            setLength(buf, (short)0, i);
            if (getLength(buf, (short)0) != (short)i) {
                System.out.format("i=%d, getLength()=%d\n", i & 0xffff, getLength(buf, (short)0) & 0xffff);
                throw new IllegalStateException("doh");
	    }
        }
    }
}
```
To run:

```
javac Flott.java && java Flott
```

